### PR TITLE
Replace deprecated use (currently only in beta) of get() on settings.

### DIFF
--- a/marker_ui_actions.py
+++ b/marker_ui_actions.py
@@ -4,7 +4,7 @@ Exposes the Marker UI and associated functionality as actions.
 
 from typing import List
 
-from talon import Module, Context, actions
+from talon import Module, Context, actions, settings
 from talon.types import Rect as TalonRect
 
 from .marker_ui import MarkerUi
@@ -52,11 +52,10 @@ class MarkerUiActions:
             marker_ui.destroy()
 
         markers = [
-            MarkerUi.Marker(
-                rect,
-                label
+            MarkerUi.Marker(rect, label)
+            for rect, label in zip(
+                rects, settings.get("user.marker_ui_labels").split(" ")
             )
-            for rect, label in zip(rects, setting_labels.get().split(" "))
         ]
 
         marker_ui = MarkerUi(markers)

--- a/mouse_helper.py
+++ b/mouse_helper.py
@@ -7,7 +7,7 @@ import math
 import subprocess
 from typing import Union, Optional, List
 
-from talon import actions, ui, clip, screen, Module
+from talon import actions, ui, clip, screen, settings, Module
 from talon.types import Rect as TalonRect
 from talon.experimental import locate
 
@@ -32,7 +32,7 @@ def get_image_template_directory():
     Gets the full path to the directory where template images are stored.
     """
 
-    maybe_value = setting_template_directory.get()
+    maybe_value = settings.get("user.mouse_helper_template_directory")
     if maybe_value:
         return maybe_value
     else:


### PR DESCRIPTION
Example:

2024-08-11 18:04:05.223 WARNING /Users/nicholas/.talon/user/talon_ui_helper/mouse_helper.py:35: DeprecationWarning: SettingsDecl: setting.get() is deprecated. Use settings.get('user.mouse_helper_template_directory')
